### PR TITLE
Refactor: Remove temporary debug logs

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -437,7 +437,6 @@ async function getConfigForRegister() {
 	if (match.length === 0) {
 		match.push("<all_urls>");
 	}
-	debugLog("[EV DEBUG] matches: %s", match);
 	return [config, match];
 }
 

--- a/src/js/rewriter.js
+++ b/src/js/rewriter.js
@@ -4,49 +4,29 @@
  * want. Such as into a proxie'd response or electron instramentation.
  */
 const rewriter = function(CONFIG) {
-  console.groupCollapsed('[EV DEBUG] rewriter() entered in frame');
-  console.log('   location.href    =', window.location.href);
-  console.log('   CONFIG.functions =', CONFIG.functions);
-  console.groupEnd();
-
   (function forceHookInnerOuterHTML() {
     for (const prop of ['innerHTML','outerHTML']) {
       // Step 1: Get the descriptor
       const desc = Object.getOwnPropertyDescriptor(Element.prototype, prop);
       if (!desc) {
-        console.warn(`[EV DEBUG] no descriptor for Element.prototype.${prop}`);
         continue;
       }
       // Step 2: Check for a setter
       const originalSet = desc.set;
       if (typeof originalSet !== 'function') {
-        console.warn(`[EV DEBUG] Element.prototype.${prop} has no setter`);
         continue;
       }
-      // Step 3: Redefine the property with logging
+      // Step 3: Redefine the property
       Object.defineProperty(Element.prototype, prop, {
         configurable: desc.configurable,
         enumerable:   desc.enumerable,
         get:          desc.get,
         set(value) {
-          console.groupCollapsed(`[EV DEBUG] set(Element.${prop}):`, value);
-          console.trace();
-          console.groupEnd();
           return originalSet.call(this, value);
         }
       });
     }
   })();
-
-  ['appendChild','replaceChild'].forEach(name => {
-    const orig = Node.prototype[name];
-    Node.prototype[name] = function(...args) {
-      console.groupCollapsed(`[EV DEBUG] Node.${name}`, args[0]);
-      console.trace();
-      console.groupEnd();
-      return orig.apply(this, args);
-    };
-  });
 
 	// Filter out known unsupported navigation sinks to avoid warnings.
 	// This is a secondary check; the primary filter is in background.js.


### PR DESCRIPTION
As requested in a follow-up, this commit removes all temporary `[EV DEBUG]` logs that were added for debugging purposes.

- In `rewriter.js`, the entry log, `innerHTML`/`outerHTML` logs, and the temporary `appendChild`/`replaceChild` hooks have been removed to clean up the console output. The core bug fix for `getOwnPropertyDescriptor` remains.
- In `background.js`, a debug log for viewing script matches has been removed.

The codebase is now cleaner and will only produce the standard `[EV]` logs during operation.