### PR TITLE
Fix: Restrict marker injection to safe sinks

### DIFF
--- a/src/js/rewriter.js
+++ b/src/js/rewriter.js
@@ -721,7 +721,7 @@ const rewriter = function(CONFIG) {
 	}
 
 	function EvalVillainHook(intrBundle, name, args, thisArg, originalFunc) {
-		const VERIFIABLE_SINKS = ['set(Element.innerHTML)', 'set(Element.outerHTML)', 'value(Element.setAttribute)'];
+		const VERIFIABLE_SINKS = ['set(Element.innerHTML)', 'set(Element.outerHTML)'];
 
 		// For now, only apply verification to a subset of sinks.
 		if (VERIFIABLE_SINKS.includes(name)) {


### PR DESCRIPTION
This commit addresses a critical bug where the Hybrid Marker Verification feature was injecting markers into sensitive sinks like `setAttribute`. This could corrupt state data (e.g., JSON in a 'value' attribute) and break website functionality, causing pages to crash or load improperly.

To immediately resolve this instability, `value(Element.setAttribute)` has been removed from the `VERIFIABLE_SINKS` list in `rewriter.js`.

This change means `setAttribute` calls will now be logged immediately without post-execution verification, preventing the site-breaking behavior while still providing visibility into the sink call. Marker verification remains active for safer HTML sinks like `innerHTML` and `outerHTML`. This is a temporary measure to ensure stability, with a more advanced 'ephemeral injection' planned for the future.