### PR TITLE
Refactor: Expand sensitive attributes list for SVG

### DIFF
--- a/src/js/rewriter.js
+++ b/src/js/rewriter.js
@@ -733,7 +733,10 @@ const rewriter = function(CONFIG) {
 			const originalArgs = [...args];
 
 			if (name === 'value(Element.setAttribute)') {
-				const SENSITIVE_ATTRS = ['width', 'height', 'maxlength', 'size', 'rows', 'cols', 'integrity', 'nonce'];
+				const SENSITIVE_ATTRS = [
+					'width', 'height', 'maxlength', 'size', 'rows', 'cols',
+					'integrity', 'nonce', 'viewBox', 'preserveAspectRatio'
+				];
 				const attrName = originalArgs[0];
 
 				if (SENSITIVE_ATTRS.includes(attrName.toLowerCase())) {


### PR DESCRIPTION
This commit expands the `SENSITIVE_ATTRS` list within the Hybrid Marker Verification logic to include common SVG attributes (`viewBox`, `preserveAspectRatio`).

This ensures that the safe, side-attribute marker injection strategy is used for these attributes, preventing the browser from throwing 'Unexpected value' warnings when they are processed and increasing the stability of the extension on pages with complex SVG content.